### PR TITLE
Assure that a default link_manager doesn't overwrite another one with…

### DIFF
--- a/djangocms_link_manager/link_manager.py
+++ b/djangocms_link_manager/link_manager.py
@@ -66,7 +66,7 @@ class LinkManager(object):
         else:
             if verify_exists:
                 try:
-                    response = urlopen(HeadRequest(url))
+                    response = urlopen(HeadRequest(url.encode("UTF-8")))
                     # NOTE: urllib should have already resolved any 301/302s
                     return 200 <= response.code < 400  # pragma: no cover
                 except (HTTPError, URLError):

--- a/djangocms_link_manager/link_manager_pool.py
+++ b/djangocms_link_manager/link_manager_pool.py
@@ -10,7 +10,8 @@ class LinkManagerPool(object):
         self._managers = {}
 
     def register(self, plugin_class, link_manager):
-        self._managers[plugin_class] = link_manager
+        if not plugin_class in self._managers:
+            self._managers[plugin_class] = link_manager
 
     def get_link_manager(self, cls):
         return self._managers.get(cls, None)


### PR DESCRIPTION
Assure that a default link_manager doesn't overwrite another one with the same name

We have a custom Plugin which is named LinkPlugin, the same name as the
djangocms-link plugin. The default link_manager from
djangocms-link-manager overwrites our manager so we made this check.
Maybe there’s a better way to check for this case.
