### PR TITLE
Allow UTF-8 strings to be passed to urlopen

### DIFF
--- a/djangocms_link_manager/link_manager.py
+++ b/djangocms_link_manager/link_manager.py
@@ -66,7 +66,7 @@ class LinkManager(object):
         else:
             if verify_exists:
                 try:
-                    response = urlopen(HeadRequest(url))
+                    response = urlopen(HeadRequest(url.encode("UTF-8")))
                     # NOTE: urllib should have already resolved any 301/302s
                     return 200 <= response.code < 400  # pragma: no cover
                 except (HTTPError, URLError):


### PR DESCRIPTION
The following url extracted by a plugin is valid but urlopen would
throw a unicode error without this change:
u'http://www.netztransparenz.de/de/Systemstabilitätsverordnung_49-5.htm'
